### PR TITLE
Exclude "oscrypto-ca-bundle.crt"

### DIFF
--- a/SyncSettings.sublime-settings
+++ b/SyncSettings.sublime-settings
@@ -19,6 +19,7 @@
     ".Spotlight-V100",
     ".Trashes",
     "ehthumbs.db",
+    "oscrypto-ca-bundle.crt",
     "Package Control.cache",
     "Package Control.last-run",
     "Package Control.merged-ca-bundle",


### PR DESCRIPTION
Added "oscrypto-ca-bundle.crt" to the "excluded_files" array.