### PR TITLE
Fix Headers formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,26 +9,26 @@ Sync Settings
 
 **Sync Settings**, is a cross-platform solution to keep the [Sublime Text](http://sublimetext.com/) configuration updated.
 
-##How it works?
+## How it works?
 
 **Sync Settings** uses Github-Gist allowing you to use all features that this service provides.
 
-##Support
+## Support
 
 * Working on Windows, Linux and OSX
 * Working on [Sublime Text 2](http://sublimetext.com/2), [Sublime Text 3](http://sublimetext.com/3)
 
-##Installation:
+## Installation:
 
 1. Install [Package Control](https://packagecontrol.io/installation)
 2. Open Package Control and looks for [Sync Settings](https://packagecontrol.io/packages/Sync%20Settings)
 
-##Configuration
+## Configuration
 
 1. Create an access [token in GitHub](https://github.com/settings/tokens/new)
 2. Paste token in configuration file `Preferences > Packages Settings > Sync Settings > Settings - User`
 
-####Options
+### Options
 
 * **access_token**: Access token provided by GitHub
 * **gist_id**: Identifier of the gist that will be used for the synchronization
@@ -66,7 +66,7 @@ Sync Settings
 }
 ```
 
-##Commands
+## Commands
 
 1. **Create and Upload**: Creates a new gist and upload your settings. The Gist identifier will be included in `Preferences > Packages Settings > Sync Settings > Settings - User` if you accept the prompt message. 
 2. **Delete and Create**: Deletes the current gist and create a new with your settings.
@@ -78,14 +78,14 @@ Sync Settings
 
 🤓 - See it in action ![SyncSettings in action!](http://g.recordit.co/I9UXWEHRHp.gif)
 
-##Tests
+## Tests
 
 You can run and add new tests using the following instructions. For more information consulting the [framework documentation](https://docs.python.org/3/library/unittest.html#module-unittest).
 
-###Requirements
+### Requirements
 For running the tests, you need install the dependencies `pip install -r requirements.txt` and python 2.7+. Also, it is necessary create an environment variable called `SYNC_ACCESS_TOKEN`.
 
-###Run tests
+### Run tests
 
 ```bash
 # Linux/OSX
@@ -102,7 +102,7 @@ python -m unittest discover -s ./tests/libs
 python -m unittest discover -s ./tests/libs -p test_<name>.py
 ```
 
-###Add Tests
+### Add Tests
 
 ```bash
 touch test_<name>.py #Create a new file
@@ -127,17 +127,17 @@ class TestExample(TestCase):
 * Johannes Weber - [@JohaWeber](https://github.com/JohaWebert)
 * [@tomahl](https://github.com/tomahl)
 
-##Issues?
+## Issues?
 
 If you find errors in the plugin, you can to execute "Show Logs" command and report a new [issue](https://github.com/mfuentesg/SyncSettings/issues/new) with the file content.
 
-##Changelog
+## Changelog
 
 You can check the changes to this plugin [here](CHANGELOG.md)
 
-##Donate
+## Donate
 
 You are welcome support this project using [Paypal](https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=7XCNSKK5W7DKJ)
 
-##License
+## License
 MIT License. © 2015-2016 Marcelo Fuentes


### PR DESCRIPTION
A space (` `) is required in between the `#` -characters and the header-text.