### PR TITLE
Update README with gist note

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Sync Settings [unmaintained]
 
 ## Configuration
 
-1. Create an access [token in GitHub](https://github.com/settings/tokens/new)
+1. Create an access [token in GitHub](https://github.com/settings/tokens/new) (select the `gist` scope)
 2. Paste token in configuration file `Preferences > Packages Settings > Sync Settings > Settings - User`
 
 ### Options


### PR DESCRIPTION
Adds a note in the Configuration section of README about selecting the `gist` scope when creating GitHub access token.  Saves future users time & adds clarity to the README - RE: Issue #84