### PR TITLE
implement: json to sublime.decode_value/encode_value conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ tests/options.json
 .idea
 cover
 .coverage
+
+pyproject.toml

--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.mfuentesg.dev

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.mfuentesg.dev

--- a/sync_settings/commands/download.py
+++ b/sync_settings/commands/download.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import json
 import os
 import sublime
 import sublime_plugin
@@ -50,7 +49,7 @@ class SyncSettingsDownloadCommand(sublime_plugin.WindowCommand):
             file_content = manager.get_content(
                 path.join(self.temp_folder, path.encode('Package Control.sublime-settings'))
             )
-            package_settings = json.loads('{}' if file_content == '' else file_content)
+            package_settings = sublime.decode_value('{}' if file_content == '' else file_content)
             # read installed_packages from remote reference and merge it with the local version
             local_settings = sublime.load_settings('Package Control.sublime-settings')
             setting = 'installed_packages'

--- a/sync_settings/libs/gist.py
+++ b/sync_settings/libs/gist.py
@@ -63,14 +63,14 @@ class Gist:
     def create(self, data):
         if not isinstance(data, dict) or not len(data):
             raise ValueError('Gist can`t be created without data')
-        return self.__do_request('post', self.make_uri(), data=sublime.encode_value(data, pretty=True)).json()
+        return self.__do_request('post', self.make_uri(), data=sublime.encode_value(data, True)).json()
 
     @auth
     @with_gid
     def update(self, gid, data):
         if not isinstance(data, dict) or not len(data):
             raise ValueError('Gist can`t be updated without data')
-        return self.__do_request('patch', self.make_uri(gid), data=sublime.encode_value(data, pretty=True).json())
+        return self.__do_request('patch', self.make_uri(gid), data=sublime.encode_value(data, True)).json()
 
     @auth
     @with_gid

--- a/sync_settings/libs/gist.py
+++ b/sync_settings/libs/gist.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import json
+import sublime
 import re
 import requests
 from functools import wraps
@@ -63,14 +63,14 @@ class Gist:
     def create(self, data):
         if not isinstance(data, dict) or not len(data):
             raise ValueError('Gist can`t be created without data')
-        return self.__do_request('post', self.make_uri(), data=json.dumps(data)).json()
+        return self.__do_request('post', self.make_uri(), data=sublime.encode_value(data, pretty=True)).json()
 
     @auth
     @with_gid
     def update(self, gid, data):
         if not isinstance(data, dict) or not len(data):
             raise ValueError('Gist can`t be updated without data')
-        return self.__do_request('patch', self.make_uri(gid), data=json.dumps(data)).json()
+        return self.__do_request('patch', self.make_uri(gid), data=sublime.encode_value(data, pretty=True).json())
 
     @auth
     @with_gid

--- a/sync_settings/sync_version.py
+++ b/sync_settings/sync_version.py
@@ -36,7 +36,7 @@ def get_remote_version():
 
 def update_config_file(info):
     with open(file_path, 'w') as f:
-        f.write(sublime.encode_value(info, pretty=True))
+        f.write(sublime.encode_value(info, True))
 
 
 def show_update_dialog(on_yes=None):

--- a/sync_settings/sync_version.py
+++ b/sync_settings/sync_version.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*
 
 import sublime
-import json
 import os
 from .libs.gist import Gist
 from .libs import settings, path
@@ -14,7 +13,7 @@ def get_local_version():
         return {}
     try:
         with open(file_path) as f:
-            return json.load(f)
+            return sublime.decode_value(f.read())
     except:  # noqa: E722
         pass
     return {}
@@ -37,7 +36,7 @@ def get_remote_version():
 
 def update_config_file(info):
     with open(file_path, 'w') as f:
-        json.dump(info, f)
+        f.write(sublime.encode_value(info, pretty=True))
 
 
 def show_update_dialog(on_yes=None):

--- a/tests/mocks/sublime_mock.py
+++ b/tests/mocks/sublime_mock.py
@@ -29,3 +29,9 @@ def load_settings(*args):
         'included_files': [],
         'excluded_files': []
     })
+
+def encode_value(*args):
+    pass
+
+def decode_value(*args):
+    pass

--- a/tests/mocks/sublime_mock.py
+++ b/tests/mocks/sublime_mock.py
@@ -1,3 +1,6 @@
+import json
+import re
+
 DIALOG_YES = 1
 
 
@@ -31,9 +34,10 @@ def load_settings(*args):
     })
 
 
-def encode_value(*args):
-    pass
+def encode_value(data, pretty):
+    return json.dumps(data)
 
 
-def decode_value(*args):
-    pass
+def decode_value(content):
+    decoded = re.sub(re.compile(r"/\*.*?\*/", re.DOTALL), "", content)
+    return json.loads(re.sub(re.compile(r"//.*?\n"), "", decoded))

--- a/tests/mocks/sublime_mock.py
+++ b/tests/mocks/sublime_mock.py
@@ -30,8 +30,10 @@ def load_settings(*args):
         'excluded_files': []
     })
 
+
 def encode_value(*args):
     pass
+
 
 def decode_value(*args):
     pass

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -43,19 +43,11 @@ class TestSyncVersion(unittest.TestCase):
         v = version.get_local_version()
         self.assertDictEqual({'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'}, v)
 
-    @mock.patch('sublime.decode_value', mock.MagicMock(return_value=True))
-    def test_get_local_version_with_encode(self):
-        def encode_value(data, pretty):
-            return json.dumps(data)
-        v = encode_value({'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'}, True)
-        self.assertEqual('{"hash": "123123123", "created_at": "2019-01-11T02:15:15Z"}', v)
-
-    @mock.patch('sublime.decode_value', mock.MagicMock(return_value=True))
-    def test_get_local_version_with_decode(self):
-        def decode_value(data):
-            return json.loads(data)
-        v = decode_value('{"hash": "123123123", "created_at": "2019-01-11T02:15:15Z"}')
-        self.assertDictEqual({'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'}, v)
+    @mock.patch('sync_settings.libs.path.exists', mock.MagicMock(return_value=True))
+    @mock.patch('sync_settings.sync_version.open',mock.mock_open(read_data='{"created_at": "2019-01-11T02:15:15Z", /* some comment */"hash": "123123123"}'),)
+    def test_get_local_version_with_commented_content(self):
+        v = version.get_local_version()
+        self.assertDictEqual({"hash": "123123123", "created_at": "2019-01-11T02:15:15Z"}, v)
 
     @mock.patch('sublime.yes_no_cancel_dialog', mock.MagicMock(return_value=1))
     def test_show_update_dialog(self):

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -45,17 +45,17 @@ class TestSyncVersion(unittest.TestCase):
 
     @mock.patch('sublime.decode_value', mock.MagicMock(return_value=True))
     def test_get_local_version_with_encode(self):
-        def encode_value:
-            return json.dumps({'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'})
-        v = encode_value()
-        self.assertDictEqual("{'created_at': '2019-01-11T02:15:15Z', 'hash': '123123123'}", v)
+        def encode_value(data, pretty):
+            return json.dumps(data)
+        v = encode_value({'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'}, True)
+        self.assertEqual('{"hash": "123123123", "created_at": "2019-01-11T02:15:15Z"}', v)
 
     @mock.patch('sublime.decode_value', mock.MagicMock(return_value=True))
     def test_get_local_version_with_decode(self):
-        def decode_value:
-            return json.loads("{'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'}")
-        v = decode_value()
-        self.assertDictEqual({'created_at': '2019-01-11T02:15:15Z', 'hash': '123123123'}, v)
+        def decode_value(data):
+            return json.loads(data)
+        v = decode_value('{"hash": "123123123", "created_at": "2019-01-11T02:15:15Z"}')
+        self.assertDictEqual({'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'}, v)
 
     @mock.patch('sublime.yes_no_cancel_dialog', mock.MagicMock(return_value=1))
     def test_show_update_dialog(self):

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 import mock
 from sync_settings import sync_version as version
@@ -41,6 +42,20 @@ class TestSyncVersion(unittest.TestCase):
     def test_get_local_version_with_content(self):
         v = version.get_local_version()
         self.assertDictEqual({'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'}, v)
+
+    @mock.patch('sublime.decode_value', mock.MagicMock(return_value=True))
+    def test_get_local_version_with_encode(self):
+        def encode_value:
+            return json.dumps({'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'})
+        v = encode_value()
+        self.assertDictEqual("{'created_at': '2019-01-11T02:15:15Z', 'hash': '123123123'}", v)
+
+    @mock.patch('sublime.decode_value', mock.MagicMock(return_value=True))
+    def test_get_local_version_with_decode(self):
+        def decode_value:
+            return json.loads("{'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'}")
+        v = decode_value()
+        self.assertDictEqual({'created_at': '2019-01-11T02:15:15Z', 'hash': '123123123'}, v)
 
     @mock.patch('sublime.yes_no_cancel_dialog', mock.MagicMock(return_value=1))
     def test_show_update_dialog(self):

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -1,4 +1,3 @@
-import json
 import unittest
 import mock
 from sync_settings import sync_version as version
@@ -44,7 +43,12 @@ class TestSyncVersion(unittest.TestCase):
         self.assertDictEqual({'hash': '123123123', 'created_at': '2019-01-11T02:15:15Z'}, v)
 
     @mock.patch('sync_settings.libs.path.exists', mock.MagicMock(return_value=True))
-    @mock.patch('sync_settings.sync_version.open',mock.mock_open(read_data='{"created_at": "2019-01-11T02:15:15Z", /* some comment */"hash": "123123123"}'),)
+    @mock.patch(
+        'sync_settings.sync_version.open',
+        mock.mock_open(
+            read_data='{"created_at": "2019-01-11T02:15:15Z", /* some comment */"hash": "123123123"}'
+        ),
+    )
     def test_get_local_version_with_commented_content(self):
         v = version.get_local_version()
         self.assertDictEqual({"hash": "123123123", "created_at": "2019-01-11T02:15:15Z"}, v)


### PR DESCRIPTION
fixes #144
fixes #119

**BLUF**
Python's json library doesn't allow for trailing comments, or comments 🤷‍♂️ because it follows JSON Spec. Sublime files however often time have these, as sublime allows them. So too accommodate for that, we use sublimes builtin encode_value and decode_value for handling json.


@mfuentesg Not sure how to implement test case. Sorry, I've not learned python 100%. Could use some general guidance. 