### PR TITLE
fix json encode (forcing UTF-8)

### DIFF
--- a/sync_settings/commands/download.py
+++ b/sync_settings/commands/download.py
@@ -34,7 +34,7 @@ class SyncSettingsDownloadCommand(sublime_plugin.WindowCommand):
         commit = g['history'][0]
         settings.update('gist_id', g['id'])
         version.update_config_file(
-            {'hash': commit['version'], 'created_at': commit['committed_at'],}
+            {'hash': commit['version'], 'created_at': commit['committed_at'], }
         )
 
     def download(self):

--- a/sync_settings/libs/gist.py
+++ b/sync_settings/libs/gist.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 
-import sublime
 import re
-import requests
 from functools import wraps
+
+import requests
+
+import sublime
 
 from .logger import logger
 
@@ -63,14 +65,14 @@ class Gist:
     def create(self, data):
         if not isinstance(data, dict) or not len(data):
             raise ValueError('Gist can`t be created without data')
-        return self.__do_request('post', self.make_uri(), data=sublime.encode_value(data, True)).json()
+        return self.__do_request('post', self.make_uri(), data=sublime.encode_value(data, True).encode("utf-8")).json()
 
     @auth
     @with_gid
     def update(self, gid, data):
         if not isinstance(data, dict) or not len(data):
             raise ValueError('Gist can`t be updated without data')
-        return self.__do_request('patch', self.make_uri(gid), data=sublime.encode_value(data, True)).json()
+        return self.__do_request('patch', self.make_uri(gid), data=sublime.encode_value(data, True).encode("utf-8")).json()
 
     @auth
     @with_gid
@@ -107,11 +109,15 @@ class Gist:
 
     @property
     def headers(self):
-        return {} if not self.token else {
-            'accept': 'application/vnd.github.v3+json',
-            'content-type': 'application/json',
-            'authorization': 'token {}'.format(self.token)
-        }
+        return (
+            {}
+            if not self.token
+            else {
+                'accept': 'application/vnd.github.v3+json',
+                'content-type': 'application/json',
+                'authorization': 'token {}'.format(self.token),
+            }
+        )
 
     @property
     def proxies(self):
@@ -122,8 +128,11 @@ class Gist:
                 r'localhost|'  # localhost...
                 r'\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})'  # ...or ip
                 r'(?::\d+)?'  # optional port
-                r'(?:/?|[/?]\S+)$', re.IGNORECASE)
+                r'(?:/?|[/?]\S+)$',
+                re.IGNORECASE,
+            )
             return url and isinstance(url, str) and re.match(regex, url) is not None
+
         proxies = dict()
         if check_proxy_url(self.http_proxy):
             proxies['http'] = self.http_proxy

--- a/sync_settings/sync_version.py
+++ b/sync_settings/sync_version.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*
 
-import sublime
 import os
+
+import sublime
+
+from .libs import path, settings
 from .libs.gist import Gist
-from .libs import settings, path
 
 file_path = path.join(os.path.expanduser('~'), '.sync_settings', 'sync.json')
 
@@ -21,10 +23,9 @@ def get_local_version():
 
 def get_remote_version():
     try:
-        commit = Gist(
-            http_proxy=settings.get('http_proxy'),
-            https_proxy=settings.get('https_proxy')
-        ).commits(settings.get('gist_id'))[0]
+        commit = Gist(http_proxy=settings.get('http_proxy'), https_proxy=settings.get('https_proxy')).commits(
+            settings.get('gist_id')
+        )[0]
         return {
             'hash': commit['version'],
             'created_at': commit['committed_at'],
@@ -40,11 +41,7 @@ def update_config_file(info):
 
 
 def show_update_dialog(on_yes=None):
-    msg = (
-        'Sync Settings:\n\n'
-        'Your settings seem out of date.\n\n'
-        'Do you want to download the latest version?'
-    )
+    msg = 'Sync Settings:\n\n' 'Your settings seem out of date.\n\n' 'Do you want to download the latest version?'
     if sublime.yes_no_cancel_dialog(msg) == sublime.DIALOG_YES:
         # call download command
         if on_yes:
@@ -61,6 +58,4 @@ def upgrade():
         return
     # TODO: check if get remote version failed
     if local['created_at'] < remote.get('created_at', ''):
-        show_update_dialog(
-            on_yes=lambda: update_config_file(remote)
-        )
+        show_update_dialog(on_yes=lambda: update_config_file(remote))

--- a/tests/mocks/sublime_mock.py
+++ b/tests/mocks/sublime_mock.py
@@ -35,7 +35,7 @@ def load_settings(*args):
 
 
 def encode_value(data, pretty):
-    return json.dumps(data)
+    return json.dumps(data, ensure_ascii=False)
 
 
 def decode_value(content):

--- a/tests/test_sync_version.py
+++ b/tests/test_sync_version.py
@@ -52,7 +52,7 @@ class TestSyncVersion(unittest.TestCase):
     )
     def test_get_local_version_with_commented_content(self):
         v = version.get_local_version()
-        self.assertDictEqual({"hash": "123123123", "created_at": "2019-01-11T02:15:15Z"},v)
+        self.assertDictEqual({"hash": "123123123", "created_at": "2019-01-11T02:15:15Z"}, v)
 
     @mock.patch('sync_settings.libs.path.exists', mock.MagicMock(return_value=True))
     @mock.patch(


### PR DESCRIPTION
fixes #165 
fixes #164 

### Problem
gist requires valid JSON. JSON must be UTF-8 encoded in order to be valid.

### Solution

We encode out data to UTF-8 prior to upload.